### PR TITLE
fix: reverse "integer" and "number" values

### DIFF
--- a/src/seed-integer.ts
+++ b/src/seed-integer.ts
@@ -1,6 +1,9 @@
 import { JSONSchema7 } from 'json-schema'
 import { faker } from '@faker-js/faker'
 
+/**
+ * @see https://json-schema.org/understanding-json-schema/reference/numeric#integer
+ */
 export function seedInteger(schema: JSONSchema7): number {
   if (schema.const) {
     return schema.const as number
@@ -10,25 +13,17 @@ export function seedInteger(schema: JSONSchema7): number {
     return schema.examples as number
   }
 
-  const minimum = schema.minimum ?? 0
-  const maximum = schema.maximum ?? minimum + 100
+  const minimum =
+    schema.exclusiveMinimum != null
+      ? schema.exclusiveMinimum + 1
+      : schema.minimum ?? 0
+  const maximum =
+    schema.exclusiveMaximum != null
+      ? schema.exclusiveMaximum - 1
+      : schema.maximum ?? minimum + 100
 
-  switch (schema.format) {
-    case 'int16':
-    case 'int32':
-    case 'int64': {
-      return faker.number.float({
-        min: minimum,
-        max: maximum,
-      })
-    }
-
-    default: {
-      return faker.number.float({
-        min: minimum,
-        max: maximum,
-        fractionDigits: 2,
-      })
-    }
-  }
+  return faker.number.int({
+    min: minimum,
+    max: maximum,
+  })
 }

--- a/src/seed-number.ts
+++ b/src/seed-number.ts
@@ -1,6 +1,9 @@
 import { JSONSchema7 } from 'json-schema'
 import { faker } from '@faker-js/faker'
 
+/**
+ * @see https://json-schema.org/understanding-json-schema/reference/numeric#number
+ */
 export function seedNumber(schema: JSONSchema7): number {
   if (schema.const) {
     return schema.const as number
@@ -10,11 +13,19 @@ export function seedNumber(schema: JSONSchema7): number {
     return schema.examples as number
   }
 
-  const minimum = schema.minimum ?? 0
-  const maximum = schema.maximum ?? minimum + 100
+  const minimum =
+    schema.exclusiveMinimum != null
+      ? schema.exclusiveMinimum + 1
+      : schema.minimum ?? 0
+  const maximum =
+    schema.exclusiveMaximum != null
+      ? schema.exclusiveMaximum - 1
+      : schema.maximum ?? minimum + 100
 
-  return faker.number.int({
+  return faker.number.float({
     min: minimum,
     max: maximum,
+    fractionDigits: schema.multipleOf != null ? undefined : 2,
+    multipleOf: schema.multipleOf,
   })
 }

--- a/tests/seed-array.test.ts
+++ b/tests/seed-array.test.ts
@@ -28,7 +28,7 @@ it.each<[string, JSONSchema7, unknown[]]>([
   [
     'returns a random array with "maxItems" set',
     { type: 'array', maxItems: 3, items: { type: 'number' } },
-    [100, 72],
+    [99.72, 72.03],
   ],
   [
     'returns a random array with "minItems" and "maxItems" set',
@@ -38,7 +38,7 @@ it.each<[string, JSONSchema7, unknown[]]>([
       maxItems: 3,
       items: { type: 'number' },
     },
-    [42, 100, 72],
+    [41.7, 99.72, 72.03],
   ],
 
   // Item type.
@@ -60,7 +60,7 @@ it.each<[string, JSONSchema7, unknown[]]>([
         type: 'number',
       },
     },
-    [100, 72, 94],
+    [99.72, 72.03, 93.26, 0.01],
   ],
   [
     'returns a random array with the "integer" item type',
@@ -70,7 +70,7 @@ it.each<[string, JSONSchema7, unknown[]]>([
         type: 'integer',
       },
     },
-    [99.72, 72.03, 93.26, 0.01],
+    [100, 72, 94],
   ],
   [
     'returns a random array with the "boolean" item type',
@@ -109,7 +109,7 @@ it.each<[string, JSONSchema7, unknown[]]>([
       items: {
         type: 'array',
         items: {
-          type: 'number',
+          type: 'integer',
         },
       },
     },

--- a/tests/seed-integer.test.ts
+++ b/tests/seed-integer.test.ts
@@ -2,16 +2,26 @@ import { JSONSchema7 } from 'json-schema'
 import { seedInteger } from '../src/seed-integer.js'
 
 it.each<[string, JSONSchema7, number | RegExp]>([
-  ['returns a random integer by default', { type: 'integer' }, 41.7],
+  ['returns a random integer by default', { type: 'integer' }, 42],
   [
     'returns a random integer with "minimum" set',
     { type: 'integer', minimum: 100 },
-    141.7,
+    142,
   ],
   [
     'returns a random integer with "maximum" set',
     { type: 'integer', maximum: 30 },
-    12.51,
+    12,
+  ],
+  [
+    'respect "exclusiveMinimum"',
+    { type: 'integer', exclusiveMinimum: 0, maximum: 2 },
+    1,
+  ],
+  [
+    'respect "exclusiveMaximum"',
+    { type: 'integer', minimum: 1, exclusiveMaximum: 2 },
+    1,
   ],
   [
     'returns the integer specified in "const"',

--- a/tests/seed-number.test.ts
+++ b/tests/seed-number.test.ts
@@ -2,16 +2,31 @@ import { JSONSchema7 } from 'json-schema'
 import { seedNumber } from '../src/seed-number.js'
 
 it.each<[string, JSONSchema7, number | RegExp]>([
-  ['returns random number by default', { type: 'number' }, 42],
+  ['returns random number by default', { type: 'number' }, 41.7],
   [
     'returns a random number with "minimum" set',
     { type: 'number', minimum: 100 },
-    142,
+    141.7,
   ],
   [
     'returns a random number with "maximum" set',
     { type: 'number', maximum: 30 },
-    12,
+    12.51,
+  ],
+  [
+    'respects "exclusiveMinimum"',
+    { type: 'number', exclusiveMinimum: 0, maximum: 2 },
+    1.42,
+  ],
+  [
+    'respects "exclusiveMaximum"',
+    { type: 'number', minimum: 1, exclusiveMaximum: 2 },
+    1,
+  ],
+  [
+    'respects "multipleOf"',
+    { type: 'number', multipleOf: 0.5, maximum: 1 },
+    0.5,
   ],
   [
     'returns the number specified in "const"',

--- a/tests/seed-object.test.ts
+++ b/tests/seed-object.test.ts
@@ -26,8 +26,8 @@ it.each<[string, JSONSchema7, object]>([
     },
     {
       string: 'fully',
-      number: 100,
-      integer: 14.67,
+      integer: 14,
+      number: 99.91,
       boolean: true,
     },
   ],


### PR DESCRIPTION
- Integer does _not_ have a floating point.
- Number _does_ have a floating point.
- Support `multipleOf`.
- Support `exclusiveMinimum` and `exclusiveMaximum`.