### PR TITLE
feat: respect "example" property from OpenAPI spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.DS_Store
 /build
 *.tsbuildinfo
+.vscode

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export type { JSONSchema } from './types.js'
+
 export { seedSchema } from './seed-schema.js'
 export { seedArray } from './seed-array.js'
 export { seedBoolean } from './seed-boolean.js'

--- a/src/seed-array.ts
+++ b/src/seed-array.ts
@@ -1,11 +1,19 @@
-import { JSONSchema7Definition } from 'json-schema'
 import { invariant } from 'outvariant'
 import { faker } from '@faker-js/faker'
 import { seedSchema } from './seed-schema.js'
+import type { JSONSchema } from './types.js'
 
-export function seedArray(schema: JSONSchema7Definition): Array<unknown> {
+export function seedArray(schema: JSONSchema | boolean): Array<unknown> {
   if (typeof schema === 'boolean') {
     return []
+  }
+
+  if (schema.example) {
+
+    if (Array.isArray(schema.example)) {
+      return schema.example
+    }
+    return typeof schema.example === 'string' ? JSON.parse(schema.example) : schema.example
   }
 
   const { items: arraySchema } = schema
@@ -20,6 +28,10 @@ export function seedArray(schema: JSONSchema7Definition): Array<unknown> {
 
   if (typeof arraySchema === 'boolean') {
     return []
+  }
+
+  if (arraySchema.example) {
+    return typeof arraySchema.example === 'string' ? [JSON.parse(arraySchema.example)] : [arraySchema.example]
   }
 
   invariant(

--- a/src/seed-boolean.ts
+++ b/src/seed-boolean.ts
@@ -1,13 +1,17 @@
-import type { JSONSchema7 } from 'json-schema'
 import { faker } from '@faker-js/faker'
+import type { JSONSchema } from './types.js'
 
-export function seedBoolean(schema: JSONSchema7): boolean {
+export function seedBoolean(schema: JSONSchema): boolean {
   if (schema.const) {
     return schema.const as boolean
   }
 
   if (schema.examples) {
     return schema.examples as boolean
+  }
+
+  if (schema.example) {
+    return typeof schema.example === 'boolean' ? schema.example : Boolean(schema.example)
   }
 
   return faker.datatype.boolean()

--- a/src/seed-integer.ts
+++ b/src/seed-integer.ts
@@ -1,16 +1,20 @@
-import { JSONSchema7 } from 'json-schema'
 import { faker } from '@faker-js/faker'
+import type { JSONSchema } from './types.js'
 
 /**
  * @see https://json-schema.org/understanding-json-schema/reference/numeric#integer
  */
-export function seedInteger(schema: JSONSchema7): number {
+export function seedInteger(schema: JSONSchema): number {
   if (schema.const) {
     return schema.const as number
   }
 
   if (schema.examples) {
     return schema.examples as number
+  }
+
+  if (schema.example) {
+    return typeof schema.example === 'number' ? schema.example : Number(schema.example)
   }
 
   const minimum =

--- a/src/seed-number.ts
+++ b/src/seed-number.ts
@@ -1,16 +1,20 @@
-import { JSONSchema7 } from 'json-schema'
 import { faker } from '@faker-js/faker'
+import type { JSONSchema } from './types.js'
 
 /**
  * @see https://json-schema.org/understanding-json-schema/reference/numeric#number
  */
-export function seedNumber(schema: JSONSchema7): number {
+export function seedNumber(schema: JSONSchema): number {
   if (schema.const) {
     return schema.const as number
   }
 
   if (schema.examples) {
     return schema.examples as number
+  }
+
+  if (schema.example) {
+    return typeof schema.example === 'number' ? schema.example : Number(schema.example)
   }
 
   const minimum =

--- a/src/seed-object.ts
+++ b/src/seed-object.ts
@@ -1,10 +1,10 @@
-import { JSONSchema7 } from 'json-schema'
 import { invariant } from 'outvariant'
 import { faker } from '@faker-js/faker'
 import { repeat } from './utils/repeat.js'
 import { seedSchema } from './seed-schema.js'
+import type { JSONSchema } from './types.js'
 
-export function seedObject(schema: JSONSchema7) {
+export function seedObject(schema: JSONSchema) {
   // Always use the explicit "default" value.
   if (schema.default) {
     return schema.default
@@ -13,6 +13,10 @@ export function seedObject(schema: JSONSchema7) {
   // Always us an explicit example, if provided.
   if (schema.examples) {
     return schema.examples
+  }
+
+  if (schema.example) {
+    return typeof schema.example === 'string' ? JSON.parse(schema.example) : schema.example
   }
 
   const json: Record<string, unknown> = {}

--- a/src/seed-schema.ts
+++ b/src/seed-schema.ts
@@ -1,12 +1,12 @@
-import { JSONSchema7 } from 'json-schema'
 import { seedString } from './seed-string.js'
 import { seedNumber } from './seed-number.js'
 import { seedInteger } from './seed-integer.js'
 import { seedBoolean } from './seed-boolean.js'
 import { seedArray } from './seed-array.js'
 import { seedObject } from './seed-object.js'
+import type { JSONSchema } from './types.js'
 
-export function seedSchema(schema: JSONSchema7) {
+export function seedSchema(schema: JSONSchema) {
   switch (schema.type) {
     case 'string': {
       return seedString(schema)

--- a/src/seed-string.ts
+++ b/src/seed-string.ts
@@ -1,16 +1,20 @@
-import { JSONSchema7 } from 'json-schema'
 import { faker } from '@faker-js/faker'
 import randexpDefaultExport from 'randexp'
+import type { JSONSchema } from './types.js'
 
 const { randexp } = randexpDefaultExport
 
-export function seedString(schema: JSONSchema7): string {
+export function seedString(schema: JSONSchema): string {
   if (schema.const) {
     return schema.const as string
   }
 
   if (schema.examples) {
     return schema.examples as string
+  }
+
+  if (schema.example) {
+    return schema.example as string
   }
 
   // Use a random value from the specified enums list.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,20 @@
+import type { JSONSchema7 } from "json-schema"
+
+declare module 'json-schema' {
+  interface JSONSchema7 {
+    /**
+     * A free-form property to include an example of an instance for this schema.
+     * To represent examples that cannot be naturally represented in JSON or YAML,
+     * a string value can be used to contain the example with escaping where necessary.
+     * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object
+     */
+    example?: JSONSchema7Type | undefined
+  }
+}
+
+/**
+ * JSON Schema v7 with OpenAPI v3 extensions
+ * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01
+ * @see https://spec.openapis.org/oas/v3.0.3
+ */
+export type JSONSchema = JSONSchema7

--- a/tests/seed-array.test.ts
+++ b/tests/seed-array.test.ts
@@ -1,7 +1,7 @@
-import { JSONSchema7 } from 'json-schema'
 import { seedArray } from '../src/seed-array.js'
+import type { JSONSchema } from '../src/types.js'
 
-it.each<[string, JSONSchema7, unknown[]]>([
+it.each<[string, JSONSchema, unknown[]]>([
   ['returns an empty array by default', { type: 'array' }, []],
   ['returns an empty array if schema is boolean', true as any, []],
   [
@@ -119,6 +119,41 @@ it.each<[string, JSONSchema7, unknown[]]>([
       [18, 39, 34],
       [40, 94, 54, 85, 42],
     ],
+  ],
+  [
+    'returns an array-level example',
+    {
+      type: 'array',
+      items: {
+        type: 'integer',
+        format: 'int64',
+      },
+      example: [1, 2, 3]
+    },
+    [1, 2, 3],
+  ],
+  [
+    'returns an array-level example if "example" is string',
+    {
+      type: 'array',
+      items: {
+        type: 'integer',
+        format: 'int64',
+      },
+      example: '[1, 2, 3]'
+    },
+    [1, 2, 3],
+  ],
+  [
+    'returns an array example if "example" provided in individual array item level',
+    {
+      type: 'array',
+      items: {
+        type: 'integer',
+        example: 1
+      },
+    },
+    [1],
   ],
 ])('%s', (_, input, output) => {
   expect(seedArray(input)).toEqual(output)

--- a/tests/seed-boolean.test.ts
+++ b/tests/seed-boolean.test.ts
@@ -1,7 +1,7 @@
-import { JSONSchema7 } from 'json-schema'
+import type { JSONSchema } from '../src/types.js'
 import { seedBoolean } from '../src/seed-boolean.js'
 
-it.each<[string, JSONSchema7, boolean]>([
+it.each<[string, JSONSchema, boolean]>([
   ['returns a random boolean by default', { type: 'boolean' }, true],
   [
     'returns the boolean specified in "const"',
@@ -11,6 +11,16 @@ it.each<[string, JSONSchema7, boolean]>([
   [
     'returns the boolean specified in "examples"',
     { type: 'boolean', examples: true },
+    true,
+  ],
+  [
+    'returns the boolean specified in "example"',
+    { type: 'boolean', example: true },
+    true,
+  ],
+  [
+    'returns the boolean specified in "example" if "example" is string',
+    { type: 'boolean', example: 'true' },
     true,
   ],
 ])('%s', (_, input, output) => {

--- a/tests/seed-integer.test.ts
+++ b/tests/seed-integer.test.ts
@@ -1,7 +1,7 @@
-import { JSONSchema7 } from 'json-schema'
+import type { JSONSchema } from '../src/types.js'
 import { seedInteger } from '../src/seed-integer.js'
 
-it.each<[string, JSONSchema7, number | RegExp]>([
+it.each<[string, JSONSchema, number | RegExp]>([
   ['returns a random integer by default', { type: 'integer' }, 42],
   [
     'returns a random integer with "minimum" set',
@@ -38,6 +38,22 @@ it.each<[string, JSONSchema7, number | RegExp]>([
       examples: 12.345,
     },
     12.345,
+  ],
+  [
+    'returns the integer specified in "example"',
+    {
+      type: 'integer',
+      example: 123,
+    },
+    123,
+  ],
+  [
+    'returns the integer specified in "example" if "example" is string',
+    {
+      type: 'integer',
+      example: '123',
+    },
+    123,
   ],
 ])('%s', (_, input, output) => {
   if (output instanceof RegExp) {

--- a/tests/seed-number.test.ts
+++ b/tests/seed-number.test.ts
@@ -1,7 +1,7 @@
-import { JSONSchema7 } from 'json-schema'
+import type { JSONSchema } from '../src/types.js'
 import { seedNumber } from '../src/seed-number.js'
 
-it.each<[string, JSONSchema7, number | RegExp]>([
+it.each<[string, JSONSchema, number | RegExp]>([
   ['returns random number by default', { type: 'number' }, 41.7],
   [
     'returns a random number with "minimum" set',
@@ -41,6 +41,22 @@ it.each<[string, JSONSchema7, number | RegExp]>([
     {
       type: 'number',
       examples: 12.345,
+    },
+    12.345,
+  ],
+  [
+    'returns the number specified in "example"',
+    {
+      type: 'number',
+      example: 12.345,
+    },
+    12.345,
+  ],
+  [
+    'returns the number specified in "example" if "example" is string',
+    {
+      type: 'number',
+      example: '12.345',
     },
     12.345,
   ],

--- a/tests/seed-object.test.ts
+++ b/tests/seed-object.test.ts
@@ -1,7 +1,7 @@
-import { JSONSchema7 } from 'json-schema'
+import type { JSONSchema } from '../src/types.js'
 import { seedObject } from '../src/seed-object.js'
 
-it.each<[string, JSONSchema7, object]>([
+it.each<[string, JSONSchema, object]>([
   ['returns an empty object by default', { type: 'object' }, {}],
   [
     'returns the "default" object if specified',
@@ -46,6 +46,16 @@ it.each<[string, JSONSchema7, object]>([
     {
       friends: ['fully', 'until'],
     },
+  ],
+  [
+    'returns the "example" object if specified',
+    { type: 'object', example: { foo: 'bar' } },
+    { foo: 'bar' },
+  ],
+  [
+    'returns the "example" object if the "example" specified as string',
+    { type: 'object', example: '{ "foo": "bar" }' },
+    { foo: 'bar' },
   ],
 ])('%s', (_, input, output) => {
   expect(seedObject(input)).toEqual(output)

--- a/tests/seed-string.test.ts
+++ b/tests/seed-string.test.ts
@@ -1,7 +1,7 @@
-import { JSONSchema7 } from 'json-schema'
 import { seedString } from '../src/seed-string.js'
+import type { JSONSchema } from '../src/types.js'
 
-it.each<[string, JSONSchema7, string | RegExp]>([
+it.each<[string, JSONSchema, string | RegExp]>([
   ['generates a random string by default', { type: 'string' }, 'fully'],
   ['respects "minLength"', { type: 'string', minLength: 10 }, 'especially'],
   [
@@ -71,7 +71,7 @@ it.each<[string, JSONSchema7, string | RegExp]>([
   [
     'returns a random "date"',
     { type: 'string', format: 'date' },
-    /2024-11-\d{2}/,
+    /2024-\d{2}-\d{2}/,
   ],
   [
     'returns a random "date" with "minimum" set',
@@ -97,7 +97,7 @@ it.each<[string, JSONSchema7, string | RegExp]>([
   [
     'returns a random "date-time"',
     { type: 'string', format: 'date-time' },
-    /^2024-11-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    /^2024-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
   ],
   [
     'returns a random "date-time" with "minimum" set',
@@ -163,6 +163,11 @@ it.each<[string, JSONSchema7, string | RegExp]>([
     'returns a random "mac"',
     { type: 'string', format: 'mac' },
     '6f:be:02:4f:23:16',
+  ],
+  [
+    'returns the "example" if defined',
+    { type: 'string', example: 'world' },
+    'world',
   ],
 ])('%s', (_, input, output) => {
   if (output instanceof RegExp) {


### PR DESCRIPTION
The OpenAPI spec allows to use "example" property on different levels of schema object.

See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object
or https://spec.openapis.org/oas/v3.0.3#schema-object


Closes: https://github.com/yellow-ticket/seed-json-schema/issues/3
