### PR TITLE
fix: support `allOf`, `oneOf`, and `anyOf` in schemas

### DIFF
--- a/src/seed-schema.ts
+++ b/src/seed-schema.ts
@@ -6,23 +6,29 @@ import { seedBoolean } from './seed-boolean.js'
 import { seedArray } from './seed-array.js'
 import { seedObject } from './seed-object.js'
 import { merge } from './utils/merge.js'
+import { isObject } from './utils/is-object.js'
 
 export function seedSchema(schema: JSONSchema7) {
   if (schema.allOf) {
-    return seedSchema(merge(schema.allOf))
+    const { allOf, ...rest } = schema
+    return seedSchema(merge([rest, ...allOf]))
   }
 
   if (schema.oneOf) {
     let first = schema.oneOf.at(0)
-    if (typeof first === 'object') {
-      return seedSchema(first)
+
+    if (isObject(first)) {
+      const { oneOf, ...rest } = schema
+      return seedSchema(merge([rest, first]))
     }
   }
 
   if (schema.anyOf) {
-    let first = schema.anyOf.at(0)
-    if (typeof first === 'object') {
-      return seedSchema(first)
+    const first = schema.anyOf.at(0)
+
+    if (isObject(first)) {
+      const { anyOf, ...rest } = schema
+      return seedSchema(merge([rest, first]))
     }
   }
 
@@ -36,7 +42,7 @@ export function seedSchema(schema: JSONSchema7) {
       })
     }
 
-    if (typeof enumValue === 'object') {
+    if (isObject(enumValue)) {
       return seedSchema({
         type: 'object',
         ...enumValue,

--- a/src/seed-schema.ts
+++ b/src/seed-schema.ts
@@ -5,8 +5,27 @@ import { seedInteger } from './seed-integer.js'
 import { seedBoolean } from './seed-boolean.js'
 import { seedArray } from './seed-array.js'
 import { seedObject } from './seed-object.js'
+import { merge } from './utils/merge.js'
 
 export function seedSchema(schema: JSONSchema7) {
+  if (schema.allOf) {
+    return seedSchema(merge(schema.allOf))
+  }
+
+  if (schema.oneOf) {
+    let first = schema.oneOf.at(0)
+    if (typeof first === 'object') {
+      return seedSchema(first)
+    }
+  }
+
+  if (schema.anyOf) {
+    let first = schema.anyOf.at(0)
+    if (typeof first === 'object') {
+      return seedSchema(first)
+    }
+  }
+
   if (schema.enum != null) {
     const enumValue = schema.enum[0]
 

--- a/src/seed-schema.ts
+++ b/src/seed-schema.ts
@@ -15,7 +15,7 @@ export function seedSchema(schema: JSONSchema7) {
   }
 
   if (schema.oneOf) {
-    let first = schema.oneOf.at(0)
+    const first = schema.oneOf.at(0)
 
     if (isObject(first)) {
       const { oneOf, ...rest } = schema

--- a/src/utils/is-object.ts
+++ b/src/utils/is-object.ts
@@ -1,0 +1,3 @@
+export function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/utils/merge.ts
+++ b/src/utils/merge.ts
@@ -1,0 +1,44 @@
+import { JSONSchema7, JSONSchema7Definition } from 'json-schema'
+
+function isObj(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function mergeObjs<T>(target: T, source: T): T {
+  if (!isObj(target) || !isObj(source)) {
+    return source
+  }
+
+  const result: T = { ...target }
+
+  for (const _key of Object.keys(source)) {
+    const key = _key as keyof T
+    const targetVal = result[key]
+    const sourceVal = source[key]
+
+    if (Array.isArray(targetVal) && Array.isArray(sourceVal)) {
+      result[key] = [...new Set([...targetVal, ...sourceVal])] as T[keyof T]
+    } else if (isObj(targetVal) && isObj(sourceVal)) {
+      result[key] = mergeObjs(targetVal, sourceVal)
+    } else {
+      result[key] = sourceVal
+    }
+  }
+
+  return result
+}
+
+function flatten(objects: JSONSchema7Definition[]): JSONSchema7Definition[] {
+  return objects.flatMap((obj) => {
+    if (typeof obj === 'boolean') return [obj]
+    if (obj.allOf) return flatten(obj.allOf)
+    return [obj]
+  })
+}
+
+export function merge(objects: JSONSchema7Definition[]): JSONSchema7 {
+  return flatten(objects).reduce<JSONSchema7>(
+    (acc, obj) => (typeof obj === 'boolean' ? acc : mergeObjs(acc, obj)),
+    {},
+  )
+}

--- a/src/utils/merge.ts
+++ b/src/utils/merge.ts
@@ -1,11 +1,8 @@
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema'
+import { isObject } from './is-object.js'
 
-function isObj(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-function mergeObjs<T>(target: T, source: T): T {
-  if (!isObj(target) || !isObj(source)) {
+function mergeObjects<T>(target: T, source: T): T {
+  if (!isObject(target) || !isObject(source)) {
     return source
   }
 
@@ -18,8 +15,8 @@ function mergeObjs<T>(target: T, source: T): T {
 
     if (Array.isArray(targetVal) && Array.isArray(sourceVal)) {
       result[key] = [...new Set([...targetVal, ...sourceVal])] as T[keyof T]
-    } else if (isObj(targetVal) && isObj(sourceVal)) {
-      result[key] = mergeObjs(targetVal, sourceVal)
+    } else if (isObject(targetVal) && isObject(sourceVal)) {
+      result[key] = mergeObjects(targetVal, sourceVal)
     } else {
       result[key] = sourceVal
     }
@@ -30,15 +27,20 @@ function mergeObjs<T>(target: T, source: T): T {
 
 function flatten(objects: JSONSchema7Definition[]): JSONSchema7Definition[] {
   return objects.flatMap((obj) => {
-    if (typeof obj === 'boolean') return [obj]
-    if (obj.allOf) return flatten(obj.allOf)
+    if (typeof obj === 'boolean') {
+      return [obj]
+    }
+
+    if (obj.allOf) {
+      return flatten(obj.allOf)
+    }
+
     return [obj]
   })
 }
 
 export function merge(objects: JSONSchema7Definition[]): JSONSchema7 {
-  return flatten(objects).reduce<JSONSchema7>(
-    (acc, obj) => (typeof obj === 'boolean' ? acc : mergeObjs(acc, obj)),
-    {},
-  )
+  return flatten(objects).reduce<JSONSchema7>((acc, value) => {
+    return typeof value === 'boolean' ? acc : mergeObjects(acc, value)
+  }, {})
 }

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -1,0 +1,56 @@
+import { merge } from "../src/utils/merge";
+
+it("merges schemas", () => {
+  expect(
+    merge([{ type: "string" }, { minLength: 1 }, { description: "abc" }]),
+  ).toEqual({
+    description: "abc",
+    type: "string",
+    minLength: 1,
+  });
+});
+
+it("overrides primitive values", () => {
+  expect(merge([{ type: "string" }, { type: "number" }])).toEqual({
+    type: "number",
+  });
+});
+
+it("deeply merges nested objects", () => {
+  expect(
+    merge([
+      { properties: { name: { type: "string" } } },
+      { properties: { age: { type: "integer" } } },
+    ]),
+  ).toEqual({
+    properties: {
+      name: { type: "string" },
+      age: { type: "integer" },
+    },
+  });
+});
+
+it("concatenates arrays", () => {
+  expect(merge([{ enum: ["a", "b"] }, { enum: ["c", "d"] }])).toEqual({
+    enum: ["a", "b", "c", "d"],
+  });
+});
+
+it("deduplicates arrays", () => {
+  expect(
+    merge([{ required: ["id", "name"] }, { required: ["name", "email"] }]),
+  ).toEqual({ required: ["id", "name", "email"] });
+});
+
+it("skips boolean schemas", () => {
+  expect(merge([true, { type: "string" }])).toEqual({ type: "string" });
+});
+
+it("flattens nested allOf arrays", () => {
+  expect(
+    merge([
+      { type: "object" },
+      { allOf: [{ required: ["id"] }, { required: ["name"] }] },
+    ]),
+  ).toEqual({ type: "object", required: ["id", "name"] });
+});

--- a/tests/seed-schema.test.ts
+++ b/tests/seed-schema.test.ts
@@ -43,6 +43,17 @@ describe("allOf", () => {
       },
       { name: "fully", age: 100, active: true },
     ],
+    [
+      "merges sibling keywords alongside allOf",
+      {
+        type: "object",
+        properties: { name: { type: "string" } },
+        allOf: [
+          { type: "object", properties: { age: { type: "integer" } } },
+        ],
+      },
+      { name: "fully", age: 100 },
+    ],
   ])("%s", (_, input, output) => {
     expect(seedSchema(input)).toEqual(output);
   });
@@ -93,6 +104,18 @@ describe("oneOf", () => {
       },
       { name: "fully" },
     ],
+    [
+      "merges sibling keywords alongside oneOf",
+      {
+        type: "object",
+        properties: { name: { type: "string" } },
+        oneOf: [
+          { type: "object", properties: { age: { type: "integer" } } },
+          { type: "object", properties: { active: { type: "boolean" } } },
+        ],
+      },
+      { name: "fully", age: 100 },
+    ],
   ])("%s", (_, input, output) => {
     expect(seedSchema(input)).toEqual(output);
   });
@@ -142,6 +165,18 @@ describe("anyOf", () => {
         ],
       },
       { name: "fully" },
+    ],
+    [
+      "merges sibling keywords alongside anyOf",
+      {
+        type: "object",
+        properties: { name: { type: "string" } },
+        anyOf: [
+          { type: "object", properties: { age: { type: "integer" } } },
+          { type: "object", properties: { active: { type: "boolean" } } },
+        ],
+      },
+      { name: "fully", age: 100 },
     ],
   ])("%s", (_, input, output) => {
     expect(seedSchema(input)).toEqual(output);

--- a/tests/seed-schema.test.ts
+++ b/tests/seed-schema.test.ts
@@ -1,0 +1,149 @@
+import type { JSONSchema7 } from "json-schema";
+import { seedSchema } from "../src/seed-schema.js";
+
+describe("allOf", () => {
+  it.each<[string, JSONSchema7, unknown]>([
+    [
+      "merges properties from multiple schemas",
+      {
+        allOf: [
+          { type: "object", properties: { name: { type: "string" } } },
+          { type: "object", properties: { age: { type: "integer" } } },
+        ],
+      },
+      { name: "fully", age: 100 },
+    ],
+    [
+      "respects allOf in properties",
+      {
+        type: "object",
+        properties: {
+          user: {
+            allOf: [
+              { type: "object", properties: { name: { type: "string" } } },
+              { type: "object", properties: { age: { type: "integer" } } },
+            ],
+          },
+        },
+      },
+      { user: { name: "fully", age: 100 } },
+    ],
+    [
+      "respects nested allOf schemas",
+      {
+        allOf: [
+          { type: "object", properties: { name: { type: "string" } } },
+          {
+            allOf: [
+              { type: "object", properties: { age: { type: "integer" } } },
+              { type: "object", properties: { active: { type: "boolean" } } },
+            ],
+          },
+        ],
+      },
+      { name: "fully", age: 100, active: true },
+    ],
+  ])("%s", (_, input, output) => {
+    expect(seedSchema(input)).toEqual(output);
+  });
+});
+
+describe("oneOf", () => {
+  it.each<[string, JSONSchema7, unknown]>([
+    [
+      "picks the first schema",
+      {
+        oneOf: [
+          { type: "object", properties: { name: { type: "string" } } },
+          { type: "object", properties: { age: { type: "integer" } } },
+        ],
+      },
+      { name: "fully" },
+    ],
+    [
+      "respects oneOf in properties",
+      {
+        type: "object",
+        properties: {
+          user: {
+            oneOf: [
+              { type: "object", properties: { name: { type: "string" } } },
+              { type: "object", properties: { age: { type: "integer" } } },
+            ],
+          },
+        },
+      },
+      { user: { name: "fully" } },
+    ],
+    [
+      "respects nested oneOf schemas",
+      {
+        oneOf: [
+          {
+            oneOf: [
+              { type: "object", properties: { name: { type: "string" } } },
+              { type: "object", properties: { age: { type: "integer" } } },
+            ],
+          },
+          {
+            type: "object",
+            properties: { active: { type: "boolean" } },
+          },
+        ],
+      },
+      { name: "fully" },
+    ],
+  ])("%s", (_, input, output) => {
+    expect(seedSchema(input)).toEqual(output);
+  });
+});
+
+describe("anyOf", () => {
+  it.each<[string, JSONSchema7, unknown]>([
+    [
+      "picks the first schema",
+      {
+        anyOf: [
+          { type: "object", properties: { name: { type: "string" } } },
+          { type: "object", properties: { age: { type: "integer" } } },
+        ],
+      },
+      { name: "fully" },
+    ],
+    [
+      "respects anyOf in properties",
+      {
+        type: "object",
+        properties: {
+          user: {
+            anyOf: [
+              { type: "object", properties: { name: { type: "string" } } },
+              { type: "object", properties: { age: { type: "integer" } } },
+            ],
+          },
+        },
+      },
+      { user: { name: "fully" } },
+    ],
+    [
+      "respects nested anyOf schemas",
+      {
+        anyOf: [
+          {
+            anyOf: [
+              { type: "object", properties: { name: { type: "string" } } },
+              { type: "object", properties: { age: { type: "integer" } } },
+            ],
+          },
+          {
+            type: "object",
+            properties: { active: { type: "boolean" } },
+          },
+        ],
+      },
+      { name: "fully" },
+    ],
+  ])("%s", (_, input, output) => {
+    expect(seedSchema(input)).toEqual(output);
+  });
+});


### PR DESCRIPTION
Adds support for seeding schemas that use `allOf`, `oneOf`, or `anyOf`

- For `allOf`, nested schemas are deeply merged before seeding
- For `oneOf` and `anyOf` we default to picking the first schema in the list

Replaces https://github.com/mswjs/source/pull/93